### PR TITLE
Update cookie extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extract session cookie in a safe manner
+
 ## [1.0.1] - 2021-05-19
 
 ### Changed
@@ -16,4 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2021-02-23
 
 ### Added
+
 - Initial release.


### PR DESCRIPTION
#### What problem is this solving?
Session cookie being extracted in a safe manner.

The session cookie extraction relied on the fact that the responses always came with the Set-Cookie header.
When Janus stopped setting its janus-sid cookie, there was no Set-Cookie present in the response.

This caused IO to be down for almost an hour.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://victormiranda2--storecomponents.myvtex.com/_v/private/vtex.session-client@1.0.1/graphiql/v1?query=query%20%7B%0A%20%20session(items%3A%20%5B%22*%22%5D)%20%7B%0A%20%20%20%20...%20on%20SessionSuccess%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20namespaces%0A%20%20%20%20%7D%0A%20%20%20%20...%20on%20SessionError%20%7B%0A%20%20%20%20%20%20type%0A%20%20%20%20%20%20message%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
