### PR TITLE
Fix GraphQL mermaid diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes GraphQL mermaid diagrams
+
 ## [1.0.4] - 2025-02-10
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ The Session Client app provides React hooks and GraphQL queries for your compone
 
 ## Installation
 
-In your React app's `manifest.json` file, add the Session Client app in the dependency list:
+In your React app's `manifest.json` file, add the Session Client app to the dependency list:
 
 ```
 "dependencies": {
@@ -12,11 +12,11 @@ In your React app's `manifest.json` file, add the Session Client app in the depe
   }
 ```
 
-> :information_source: *You can have full TypeScript support running `vtex setup --typings` in your CLI afterwards.*
+> ℹ️ You can have full TypeScript support running `vtex setup --typings` in your CLI afterwards.
 
 ## Configuration
 
-The Session Client's React hooks allow you to read and update the VTEX Session cookie as desired. On the other hand, the GraphQL query and mutation enable your app to fetch the current user session and change it, respectively.
+The Session Client's React hooks allow you to read and update the VTEX Session cookie as desired. On the other hand, the GraphQL query and mutation enable your app to fetch and change the current user session.
 
 ### React hooks
 
@@ -33,7 +33,7 @@ To update the VTEX Session cookie:
 
 #### `useRenderSession` hook
 
-This hook is the fastest way to access a session data, using the session response from `render-session`. One caveat: the session values are limited to a [set of values](https://github.com/vtex-apps/render-session/blob/master/src/constants.ts). If you need fields that are not in this set, you can use [`useFullSession`](#useFullSession) or [`useLazyFullSession`](#useLazyFullSession).
+This hook is the fastest way to access session data, using the session response from `render-session`. One caveat: the session values are limited to a [set of values](https://github.com/vtex-apps/render-session/blob/master/src/constants.ts). If you need fields that are not in this set, you can use [`useFullSession`](#useFullSession) or [`useLazyFullSession`](#useLazyFullSession).
 
 ```tsx
 import React from 'react'
@@ -60,7 +60,7 @@ export default MyComponent
 
 #### `useFullSession` hook
 
-> ⚠️ *It's not possible to return the session during Server Side Rendering, since it is a private query.*
+> ⚠️ It's not possible to return the session during Server Side Rendering since it is a private query.
 
 Runs a GraphQL query on the client side to query the full user session.
 
@@ -90,7 +90,7 @@ function MyComponent() {
 export default MyComponent
 ```
 
-It also accepts a GraphQL variable called `items` which is an array of strings. These strings should match attributes inside of the Session object, and only those attributes will be then fetched and returned.
+It also accepts a GraphQL variable called `items` which is an array of strings. These strings should match attributes inside the Session object, and only those attributes will be then fetched and returned.
 
 For example:
 
@@ -104,7 +104,7 @@ useFullSession({
 
 #### `useLazyFullSession` hook
 
-The same as [`useFullSession`](#useFullSession) but it uses React Apollo's `useLazyQuery` hook instead. You can read more about `useLazyQuery` API [here](https://www.apollographql.com/docs/react/api/react/hooks/#uselazyquery).
+The same as [`useFullSession`](#useFullSession), but it uses React Apollo's `useLazyQuery` hook instead. You can read more about `useLazyQuery` API [here](https://www.apollographql.com/docs/react/api/react/hooks/#uselazyquery).
 
 ```tsx
 import React from 'react'
@@ -121,7 +121,7 @@ function MyComponent() {
 export default MyComponent
 ```
 
-It also accepts a GraphQL variable called `items` which is an array of strings. These strings should match attributes inside of the Session object, and only those attributes will be then fetched and returned.
+It also accepts a GraphQL variable called `items`, which is an array of strings. These strings should match attributes inside the Session object, and only those attributes will be then fetched and returned.
 
 For example:
 
@@ -137,7 +137,7 @@ useLazyFullSession({
 
 Updates the values of a session. Under the hood, it uses React Apollo's `useMutation` hook. You can read more about `useMutation` API [here](https://www.apollographql.com/docs/react/api/react/hooks/#usemutation).
 
-Differently from the `useMutation` hook, this one only returns the mutation function (called in the example below as `updateSession`) — It does not return the mutation result. 
+Unlike the `useMutation` hook, this one only returns the mutation function (called in the example below as `updateSession`) — it does not return the mutation result. 
 
 After calling the mutation function, the hook reloads the page, guaranteeing that the whole page data is updated to the new session parameters. This is extremely useful in pages where the content changes according to the session values, such as the search results. 
 
@@ -199,7 +199,7 @@ function MyComponent() {
 export default MyComponent
 ```
 
-It also accepts a GraphQL variable called `items` which is an array of strings. These strings should match attributes inside of the Session object, and only those attributes will be then fetched and returned.
+It also accepts a GraphQL variable called `items`, which is an array of strings. These strings should match attributes inside of the Session object, and only those attributes will be then fetched and returned.
 
 For example:
 

--- a/docs/session-client-graphql-api.md
+++ b/docs/session-client-graphql-api.md
@@ -15,9 +15,6 @@ classDiagram
     session(items [String]) Session
   }
 
-  class Session {
-  }
-
   class SessionError {
     String type
     String message
@@ -71,9 +68,6 @@ classDiagram
 
     class Mutation {
         updateSession(fields SessionFieldsJSONInput!, items [String]) Session
-    }
-
-    class Session {
     }
 
     class SessionError {


### PR DESCRIPTION
Fix GraphQL mermaid diagrams. Remove empty `Session` class.